### PR TITLE
fix phpunit warning because of wip tests

### DIFF
--- a/tests/unit/share/ScienceMeshShareTest.php
+++ b/tests/unit/share/ScienceMeshShareTest.php
@@ -5,6 +5,10 @@ namespace OCA\ScienceMesh\Tests\Unit;
 use PHPUnit_Framework_TestCase;
 
 class ScienceMeshShareTest extends PHPUnit_Framework_TestCase {
+	//remove warning, delete after real tests get into the branch
+	public function testNothing() {
+		$this->assertEquals(true, true);
+	}
 	/*
 		public function testFromJson() {  //TODO
 			return(false);


### PR DESCRIPTION
just adding a dummy test to ScienceMeshShareTest so the warning about the empty test class goes away