### PR TITLE
UpdateReceivedShare

### DIFF
--- a/lib/Controller/RevaController.php
+++ b/lib/Controller/RevaController.php
@@ -976,7 +976,7 @@ class RevaController extends Controller {
 	public function GetReceivedShare($userId) {
 		$opaqueId = $this->request->getParam("Spec")["Id"]["opaque_id"];
 		$name = $this->getNameByOpaqueId($opaqueId);
-		try{
+		try {
 			$share = $this->shareProvider->getReceivedShareByToken($opaqueId);
 			$response = $this->shareInfoToResourceInfo($share);
 			$response["state"] = 2;

--- a/lib/Controller/RevaController.php
+++ b/lib/Controller/RevaController.php
@@ -919,14 +919,16 @@ class RevaController extends Controller {
 		$resourceId = $this->request->getParam("received_share")["share"]["resource_id"];
 		$permissions = $this->request->getParam("received_share")["share"]["permissions"];
 		$permissionsCode = $this->getPermissionsCode($permissions);
-		if (!($share = $this->shareProvider->getReceivedhareByToken(urldecode($resourceId)))) {
-			return new JSONResponse(["error" => "UpdateSentShare failed"], Http::STATUS_INTERNAL_SERVER_ERROR);
+		try {
+			$share = $this->shareProvider->getReceivedShareByToken($resourceId);
+			$share->setPermissions($permissionsCode);
+			$shareUpdate = $this->shareProvider->UpdateReceivedShare($share);
+			$response = $this->shareInfoToResourceInfo($shareUpdate);
+			$response["state"] = 2;
+			return new JSONResponse($response, Http::STATUS_OK);
+		} catch (\Exception $e) {
+			return new JSONResponse(["error" => $e->getMessage()], Http::STATUS_INTERNAL_SERVER_ERROR);
 		}
-		$share->setPermissions($permissionsCode);
-		$shareUpdated = $this->shareProvider->updateReceivedShare($share);
-		$response = $this->shareInfoToResourceInfo($shareUpdated);
-		$response["state"] = 2;
-		return new JSONResponse($response, Http::STATUS_OK);
 	}
 	/**
 	 * @PublicPage

--- a/lib/Controller/RevaController.php
+++ b/lib/Controller/RevaController.php
@@ -977,7 +977,7 @@ class RevaController extends Controller {
 		$opaqueId = $this->request->getParam("Spec")["Id"]["opaque_id"];
 		$name = $this->getNameByOpaqueId($opaqueId);
 
-		$share = $this->shareProvider->getReceivedhareByToken($opaqueId);
+		$share = $this->shareProvider->getReceivedShareByToken($opaqueId);
 		if ($share) {
 			$response = $this->shareInfoToResourceInfo($share);
 			$response["state"] = 2;

--- a/lib/Controller/RevaController.php
+++ b/lib/Controller/RevaController.php
@@ -976,14 +976,14 @@ class RevaController extends Controller {
 	public function GetReceivedShare($userId) {
 		$opaqueId = $this->request->getParam("Spec")["Id"]["opaque_id"];
 		$name = $this->getNameByOpaqueId($opaqueId);
-
-		$share = $this->shareProvider->getReceivedShareByToken($opaqueId);
-		if ($share) {
+		try{
+			$share = $this->shareProvider->getReceivedShareByToken($opaqueId);
 			$response = $this->shareInfoToResourceInfo($share);
 			$response["state"] = 2;
 			return new JSONResponse($response, Http::STATUS_OK);
+		} catch (\Exception $e) {
+			return new JSONResponse(["error" => $e->getMessage()],Http::STATUS_BAD_REQUEST);
 		}
-		return new JSONResponse(["error" => "GetReceivedShare failed"],Http::STATUS_BAD_REQUEST);
 	}
 
 	/**

--- a/lib/ShareProvider/ScienceMeshShareProvider.php
+++ b/lib/ShareProvider/ScienceMeshShareProvider.php
@@ -461,9 +461,7 @@ class ScienceMeshShareProvider implements IShareProvider {
 		$qb = $this->dbConnection->getQueryBuilder();
 		$qb->update('share_external')
 				->where($qb->expr()->eq('id', $qb->createNamedParameter($share->getId())))
-				->set('permissions', $qb->createNamedParameter($share->getPermissions()))
-				->set('uid_owner', $qb->createNamedParameter($share->getShareOwner()))
-				->set('uid_initiator', $qb->createNamedParameter($share->getSharedBy()))
+				->set('owner', $qb->createNamedParameter($share->getShareOwner()))
 				->execute();
 		return $share;
 	}
@@ -898,7 +896,7 @@ class ScienceMeshShareProvider implements IShareProvider {
 	 * @return IShare
 	 * @throws ShareNotFound
 	 */
-	public function getReceivedhareByToken($token) {
+	public function getReceivedShareByToken($token) {
 		$qb = $this->dbConnection->getQueryBuilder();
 		$cursor = $qb->select('*')
 			->from('share_external')

--- a/lib/ShareProvider/ScienceMeshShareProvider.php
+++ b/lib/ShareProvider/ScienceMeshShareProvider.php
@@ -1287,18 +1287,30 @@ class ScienceMeshShareProvider implements IShareProvider {
 			return false;
 		}
 		$id = $data['fileid'];
-		$qb->delete('share')
+		$isShare = $qb->select('*')
+			->from('share')
 			->where(
 				$qb->expr()->eq('uid_owner', $qb->createNamedParameter($userId))
 			)
 			->andWhere(
 				$qb->expr()->eq('item_source', $qb->createNamedParameter($id))
-			);
-		$qb->execute();
-		return true;
+			)
+			->execute()
+			->fetch();
+		if ($isShare) {
+			$qb->delete('share')
+				->where(
+					$qb->expr()->eq('uid_owner', $qb->createNamedParameter($userId))
+				)
+				->andWhere(
+					$qb->expr()->eq('item_source', $qb->createNamedParameter($id))
+				);
+			$qb->execute();
+			return true;
+		}
+		return false;
 	}
 	public function deleteReceivedShareByOpaqueId($userId, $opaqueId) {
-		error_log(urldecode($opaqueId));
 		$qb = $this->dbConnection->getQueryBuilder();
 		$qb->select('*')
 			->from('share_external')

--- a/tests/unit/controller/RevaControllerTest.php
+++ b/tests/unit/controller/RevaControllerTest.php
@@ -1895,7 +1895,7 @@ class RevaControllerTest extends PHPUnit_Framework_TestCase {
 					]
 				]
 				);
-		$this->shareProvider->method("getReceivedhareByToken")
+		$this->shareProvider->method("getReceivedShareByToken")
 			->willReturn($testShare);
 		$response = [
 			"id" => [
@@ -1974,8 +1974,8 @@ class RevaControllerTest extends PHPUnit_Framework_TestCase {
 					]
 				]
 				);
-		$this->shareManager->method("getShareById")
-			->willReturn(null);
+		$this->shareProvider->method("getReceivedShareByToken")
+			->willThrowException(new \OCP\Share\Exceptions\ShareNotFound());
 		$result = $controller->GetReceivedShare($this->userId);
 		$this->assertEquals($result->getStatus(),400);
 	}


### PR DESCRIPTION
So this does not really fix https://github.com/pondersource/nc-sciencemesh/issues/193, but it's allows for a full cycle of ```ListReceivedShares => [],
AddReceivedShare => {...},
ListReceivedShares => [{...}]
UpdateReceivedShare => {...},
GetReceivedShare => {...},
Unshare,
ListReceivedShares => []```
UpdateReceivedShare just basically doesn't do anything because it works on the share_external table, that doesn't really have any fields that we can meaningfully update...