### PR TITLE
Error handling for 500 error trying to authenticate non-existing user

### DIFF
--- a/lib/Controller/RevaController.php
+++ b/lib/Controller/RevaController.php
@@ -119,7 +119,8 @@ class RevaController extends Controller {
 		$this->userId = $userId;
 		$this->checkRevadAuth();
 		if ($userId) {
-			$this->userFolder = $this->rootFolder->getUserFolder($userId);
+			if($this->rootFolder->nodeExists($userId))
+				$this->userFolder = $this->rootFolder->getUserFolder($userId);
 		}
 	}
 


### PR DESCRIPTION
@michielbdejong I added a line that check if node exists based on the userId(clientID) 

First test:
run this ```curl -i -d'{"clientID":"JJU3gaYTE1MpJtGaNNBUD5HZFoXzYEG8","clientSecret":""}' -H 'x-reva-secret: shared-secret-2' -H 'Content-Type: application/json' https://oc2.docker/index.php/apps/sciencemesh/~JJU3gaYTE1MpJtGaNNBUD5HZFoXzYEG8/api/auth/Authenticate```
result:
```
HTTP/1.1 401 Unauthorized
Date: Fri, 16 Jun 2023 17:25:01 GMT
Server: Apache/2.4.57 (Ubuntu)
Set-Cookie: ocz2lbzmrp2p=i4uivk381cbf77vg7fk3ds7ig8; path=/; secure; HttpOnly; SameSite=Strict
Expires: Thu, 19 Nov 1981 08:52:00 GMT
Cache-Control: no-cache, no-store, must-revalidate
Pragma: no-cache
Set-Cookie: oc_sessionPassphrase=2nK54DOFOia7n%2FNJ9gmfSWvHGpvQ9EXszhP95pjG9znIwaYA0AlqEOT9F8Di2yYsfnE6XLcRC3Vff1J32LscKROS9qdRtVadwJjIsOoexzT7Or0CUhvBloD1LKd1h1pj; expires=Fri, 16-Jun-2023 17:45:01 GMT; Max-Age=1200; path=/; secure; HttpOnly; SameSite=Strict
Content-Security-Policy: default-src 'none';manifest-src 'self';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self';connect-src 'self';media-src 'self'
X-XSS-Protection: 0
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
X-Robots-Tag: none
X-Download-Options: noopen
X-Permitted-Cross-Domain-Policies: none
Content-Length: 37
Content-Type: application/json; charset=utf-8
```

Second test:
run this ```curl -i -d'{"clientID":"marie","clientSecret":"radioactivity"}' -H 'x-reva-secret: shared-secret-2' -H 'Content-Type: application/json' https://oc2.docker/index.php/apps/sciencemesh/~marie/api/auth/Authenticate```
result:
```
HTTP/1.1 200 OK
Date: Fri, 16 Jun 2023 17:27:11 GMT
Server: Apache/2.4.57 (Ubuntu)
Set-Cookie: ocz2lbzmrp2p=aln0giuk57l3a9qm71dsutoo3k; path=/; secure; HttpOnly; SameSite=Strict
Expires: Thu, 19 Nov 1981 08:52:00 GMT
Cache-Control: no-cache, no-store, must-revalidate
Pragma: no-cache
Set-Cookie: oc_sessionPassphrase=vdVrYWDxr4qdEAlsMmNNhNHiBOe6CI6c9MWccrgqrIFR6sMP8VL6EKb0Wn8%2F281HLHqQRdFQdjeoBpxv2I6Z304FVzkkKmVVFiA3N2OE3IUA8ZwAHgefmpggZ0M%2FyFDB; expires=Fri, 16-Jun-2023 17:47:11 GMT; Max-Age=1200; path=/; secure; HttpOnly; SameSite=Strict
Content-Security-Policy: default-src 'none';manifest-src 'self';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self';connect-src 'self';media-src 'self'
X-XSS-Protection: 0
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
X-Robots-Tag: none
X-Download-Options: noopen
X-Permitted-Cross-Domain-Policies: none
Content-Length: 315
Content-Type: application/json; charset=utf-8